### PR TITLE
formulaic 0.6.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<37]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,26 +10,28 @@ source:
   sha256: 54905a297a40f6d8b23b94b6652d622ad4756a2b14fb83c0aa76473254d4dd7b
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<37]
 
 requirements:
   host:
-    - python >=3.7.2
+    - python
     - pip
-    - hatch
+    - hatchling
     - hatch-vcs
+    - setuptools
+    - wheel
   run:
-    - python >=3.7.2
+    - python
     - astor >=0.8
-    - cached_property
-    - graphlib-backport
-    - interface_meta >=1.2
+    - cached-property >=1.3.0  # [py<38]
+    - graphlib-backport >= 1.0.0  # [py<39]
+    - interface_meta >=1.2.0
     - numpy >=1.16.5
     - pandas >=1.0
     - scipy >=1.6
-    - typing-extensions >=4.2
+    - typing-extensions >=4.2.0
     - wrapt >=1.0
   run_constrained:
     - pyarrow >=1
@@ -38,6 +40,10 @@ requirements:
 test:
   imports:
     - formulaic
+  requires: 
+    - pip
+  commands: 
+    - pip check
 
 about:
   home: https://github.com/matthewwardrop/formulaic

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
     - astor >=0.8
     - cached-property >=1.3.0  # [py<38]
-    - graphlib-backport >= 1.0.0  # [py<39]
+    - graphlib-backport >=1.0.0  # [py<39]
     - interface_meta >=1.2.0
     - numpy >=1.16.5
     - pandas >=1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - typing-extensions >=4.2.0
     - wrapt >=1.0
   run_constrained:
+    - python >=3.7.2
     - pyarrow >=1
     - sympy >=1.3,!=1.10
 


### PR DESCRIPTION
Changelog: https://github.com/matthewwardrop/formulaic/releases
License: https://github.com/matthewwardrop/formulaic/blob/v0.6.2/LICENSE
Requirements: https://github.com/matthewwardrop/formulaic/blob/v0.6.2/pyproject.toml


Actions:
1. Apply an initial **percy** [patch](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/test_patch.json) and run locally a [script](https://github.com/anaconda-distribution/percy/blob/main/percy/examples/patch/updater_standalone.py) to: 
  - Remove `noarch python`
  - Skip `py<37`
  - Add flags `--no-deps --no-build-isolation` to `script`
  - Add missing `setuptools` and `wheel` to `host`
  - Fix `python` in `host` and `run`
  - Add `pip check`
2. Rename `hatch` as `hatchling`, see https://github.com/matthewwardrop/formulaic/blob/v0.6.2/LICENSE
3. Update runtime pinnings and add constraints

Notes:
- `lifelines` requires it https://github.com/conda-forge/lifelines-feedstock/blob/532bab4fccd8407f9e4e4010ab6733951ef254e8/recipe/meta.yaml#L37