### PR TITLE
Fix_python

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+channels:
+  - sk_test
+upload_without_merge: True

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<37]
+  skip: True  # [py<38]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,6 @@ requirements:
     - typing-extensions >=4.2.0
     - wrapt >=1.0
   run_constrained:
-    - python >=3.7.2
     - pyarrow >=1
     - sympy >=1.3,!=1.10
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 54905a297a40f6d8b23b94b6652d622ad4756a2b14fb83c0aa76473254d4dd7b
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<38]
 


### PR DESCRIPTION
Actions:
1. Bump build number
2. Skip `py<38` because we do not build for py<38
3. Remove python `>=3.7.2` from `run_constrained` because the downstream package cannot be built with it, see https://github.com/AnacondaRecipes/lifelines-feedstock/pull/2 